### PR TITLE
requestId for refunds

### DIFF
--- a/spec/Model/RefundSpec.php
+++ b/spec/Model/RefundSpec.php
@@ -47,4 +47,11 @@ class RefundSpec extends ObjectBehavior
         $this->setAmount($amount)->shouldReturn($this);
         $this->getAmount()->shouldReturn($amount);
     }
+
+    function its_request_id_is_mutable()
+    {
+        $this->getRequestId()->shouldReturn(null);
+        $this->setRequestId('requestId-1234')->shouldReturn($this);
+        $this->getRequestId()->shouldReturn('requestId-1234');
+    }
 }

--- a/spec/Service/PaymentsSpec.php
+++ b/spec/Service/PaymentsSpec.php
@@ -64,7 +64,7 @@ class PaymentsSpec extends ObjectBehavior
         $exception = new ClientException('ddssda', $request, $response);
 
         $client->get('payments', Argument::any())->willThrow($exception);
-        
+
         $serializer->deserialize(Argument::any(), ErrorResponse::class, 'json')->shouldBeCalled()->willReturn($errorResponse);
 
         $this->shouldThrow(ApiException::class)->duringListPayments();
@@ -254,7 +254,7 @@ class PaymentsSpec extends ObjectBehavior
         $exception = new ClientException('ddssda', $request, $response);
 
         $client->post('payments/23841566/void', Argument::any())->willThrow($exception);
-        
+
         $serializer->deserialize(Argument::any(), ErrorResponse::class, 'json')->shouldBeCalled()->willReturn($errorResponse);
 
         $this->shouldThrow(ApiException::class)->duringVoid('23841566');
@@ -271,14 +271,15 @@ class PaymentsSpec extends ObjectBehavior
 
         $serializer->serialize([
             'amount' => $refundAmount,
-            'merchantReference' => 'my_reference'
+            'merchantReference' => 'my_reference',
+            'requestId' => 'my_request_id',
         ], 'json')->shouldBeCalled();
         $serializer->deserialize($json, Refund::class, 'json')->shouldBeCalled();
         $stream->getContents()->willReturn($json);
         $response->getBody()->willReturn($stream);
         $client->post('payments/23841566/refund', Argument::any())->willReturn($response);
 
-        $this->refund('23841566', $refundAmount, 'my_reference');
+        $this->refund('23841566', $refundAmount, 'my_reference', 'my_request_id');
     }
 
     function it_can_handle_refund_error(
@@ -299,7 +300,8 @@ class PaymentsSpec extends ObjectBehavior
         $serializer->serialize(
             [
                 'amount' => $refundAmount,
-                'merchantReference' => 'my_reference'
+                'merchantReference' => 'my_reference',
+                'requestId' => 'my_request_id',
             ],
             'json'
         )->shouldBeCalled();
@@ -309,6 +311,6 @@ class PaymentsSpec extends ObjectBehavior
             ->shouldBeCalled()
             ->willReturn($errorResponse);
 
-        $this->shouldThrow(ApiException::class)->duringRefund('23841566', $refundAmount, 'my_reference');
+        $this->shouldThrow(ApiException::class)->duringRefund('23841566', $refundAmount, 'my_reference', 'my_request_id');
     }
 }

--- a/src/Model/Refund.php
+++ b/src/Model/Refund.php
@@ -27,6 +27,10 @@ class Refund
      * @var Money
      */
     protected $amount;
+    /**
+     * @var string
+     */
+    protected $requestId;
 
     /**
      * @return string
@@ -58,6 +62,14 @@ class Refund
     public function getAmount()
     {
         return $this->amount;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRequestId()
+    {
+        return $this->requestId;
     }
 
     /**
@@ -100,6 +112,17 @@ class Refund
     public function setAmount(Money $amount)
     {
         $this->amount = $amount;
+
+        return $this;
+    }
+
+    /**
+    * @param string $requestId
+    * @return $this
+    */
+    public function setRequestId($requestId)
+    {
+        $this->requestId = $requestId;
 
         return $this;
     }

--- a/src/Serializer/CultureKings.Afterpay.Model.Refund.yml
+++ b/src/Serializer/CultureKings.Afterpay.Model.Refund.yml
@@ -11,3 +11,6 @@ CultureKings\Afterpay\Model\Refund:
       serialized_name: merchantReference
     amount:
       type: CultureKings\Afterpay\Model\Money
+    requestId:
+      type: string
+      serialized_name: requestId

--- a/src/Service/Payments.php
+++ b/src/Service/Payments.php
@@ -288,7 +288,7 @@ class Payments
         $request = [
             'amount' => $amount,
             'merchantReference' => $merchantReference,
-            'requestId' => $requestId
+            'requestId' => $requestId,
         ];
 
         try {

--- a/src/Service/Payments.php
+++ b/src/Service/Payments.php
@@ -280,13 +280,15 @@ class Payments
      * @param string $paymentId
      * @param Money  $amount
      * @param string $merchantReference
+     * @param string $requestId
      * @return array|\JMS\Serializer\scalar|object
      */
-    public function refund($paymentId, Money $amount, $merchantReference = '')
+    public function refund($paymentId, Money $amount, $merchantReference = '', $requestId = '')
     {
         $request = [
             'amount' => $amount,
             'merchantReference' => $merchantReference,
+            'requestId' => $requestId
         ];
 
         try {


### PR DESCRIPTION
- Add support/tests for requestId in payment refunds
- Add requestId to refund model, it is provided by some API calls
