### PR TITLE
Allow setting of user agent as recommended by AfterPay

### DIFF
--- a/src/Factory/MerchantApi.php
+++ b/src/Factory/MerchantApi.php
@@ -28,10 +28,10 @@ class MerchantApi extends Api
         Client $client = null,
         SerializerInterface $serializer = null
     ) {
-    
+
         AnnotationRegistry::registerLoader('class_exists');
 
-        $afterpayClient = $client ? : new Client([ 'base_uri' => $authorization->getEndpoint() ]);
+        $afterpayClient = $client ? : new Client([ 'base_uri' => $authorization->getEndpoint(), 'defaults' => [ 'headers' => ['User-Agent' => $authorization->getUserAgent() ] ] ]);
         $afterpaySerializer = $serializer ? : SerializerFactory::getSerializer();
 
         return new ConfigurationService($afterpayClient, $authorization, $afterpaySerializer);
@@ -48,10 +48,10 @@ class MerchantApi extends Api
         Client $client = null,
         SerializerInterface $serializer = null
     ) {
-    
+
         AnnotationRegistry::registerLoader('class_exists');
 
-        $afterpayClient = $client ? : new Client([ 'base_uri' => $authorization->getEndpoint() ]);
+        $afterpayClient = $client ? : new Client([ 'base_uri' => $authorization->getEndpoint(), 'defaults' => [ 'headers' => ['User-Agent' => $authorization->getUserAgent() ] ] ]);
         $afterpaySerializer = $serializer ? : SerializerFactory::getSerializer();
 
         return new PaymentsService($afterpayClient, $authorization, $afterpaySerializer);
@@ -70,7 +70,7 @@ class MerchantApi extends Api
     ) {
         AnnotationRegistry::registerLoader('class_exists');
 
-        $afterpayClient = $client ? : new Client([ 'base_uri' => $authorization->getEndpoint() ]);
+        $afterpayClient = $client ? : new Client([ 'base_uri' => $authorization->getEndpoint(), 'defaults' => [ 'headers' => ['User-Agent' => $authorization->getUserAgent() ] ] ]);
         $afterpaySerializer = $serializer ? : SerializerFactory::getSerializer();
 
         return new OrdersService($afterpayClient, $authorization, $afterpaySerializer);
@@ -93,3 +93,4 @@ class MerchantApi extends Api
         return new PingService($afterpayClient);
     }
 }
+

--- a/src/Factory/MerchantApi.php
+++ b/src/Factory/MerchantApi.php
@@ -31,7 +31,7 @@ class MerchantApi extends Api
 
         AnnotationRegistry::registerLoader('class_exists');
 
-        $afterpayClient = $client ? : new Client([ 'base_uri' => $authorization->getEndpoint(), 'defaults' => [ 'headers' => ['User-Agent' => $authorization->getUserAgent() ] ] ]);
+        $afterpayClient = $client ? : new Client([ 'base_uri' => $authorization->getEndpoint(), 'headers' => ['User-Agent' => $authorization->getUserAgent() ] ]);
         $afterpaySerializer = $serializer ? : SerializerFactory::getSerializer();
 
         return new ConfigurationService($afterpayClient, $authorization, $afterpaySerializer);
@@ -51,7 +51,7 @@ class MerchantApi extends Api
 
         AnnotationRegistry::registerLoader('class_exists');
 
-        $afterpayClient = $client ? : new Client([ 'base_uri' => $authorization->getEndpoint(), 'defaults' => [ 'headers' => ['User-Agent' => $authorization->getUserAgent() ] ] ]);
+        $afterpayClient = $client ? : new Client([ 'base_uri' => $authorization->getEndpoint(), 'headers' => ['User-Agent' => $authorization->getUserAgent() ] ]);
         $afterpaySerializer = $serializer ? : SerializerFactory::getSerializer();
 
         return new PaymentsService($afterpayClient, $authorization, $afterpaySerializer);
@@ -70,7 +70,7 @@ class MerchantApi extends Api
     ) {
         AnnotationRegistry::registerLoader('class_exists');
 
-        $afterpayClient = $client ? : new Client([ 'base_uri' => $authorization->getEndpoint(), 'defaults' => [ 'headers' => ['User-Agent' => $authorization->getUserAgent() ] ] ]);
+        $afterpayClient = $client ? : new Client([ 'base_uri' => $authorization->getEndpoint(), 'headers' => ['User-Agent' => $authorization->getUserAgent() ] ]);
         $afterpaySerializer = $serializer ? : SerializerFactory::getSerializer();
 
         return new OrdersService($afterpayClient, $authorization, $afterpaySerializer);

--- a/src/Model/Merchant/Authorization.php
+++ b/src/Model/Merchant/Authorization.php
@@ -27,6 +27,10 @@ class Authorization implements AuthorizationInterface
      * @var string
      */
     protected $secret;
+    /**
+     * @var string
+     */
+    protected $user_agent;
 
     /**
      * Authorization constructor.
@@ -97,4 +101,24 @@ class Authorization implements AuthorizationInterface
 
         return $this;
     }
+
+
+    /**
+     * @param string $user_agent
+     * @return $this
+     */
+    public function setUserAgent($user_agent)
+    {
+        $this->user_agent = $user_agent;
+
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getUserAgent()
+    {
+        return $this->user_agent;
+    }
 }
+


### PR DESCRIPTION
AfterPay now require (although their api says recommend only) that a user agent is sent through on the request.
https://docs.afterpay.com/au-online-api-v1.html#request-headers
This pull request adds the capability for the user agent to be set instead of just Guzzle's default header.